### PR TITLE
Update path to VTK git repository

### DIFF
--- a/cmake/externals/projects_modules/VTK.cmake
+++ b/cmake/externals/projects_modules/VTK.cmake
@@ -51,7 +51,7 @@ EP_SetDirectories(${ep}
 # Set GIT_TAG to latest commit of origin/release-5.10 known to work
 set(tag tags/v5.10.1)
 if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(location GIT_REPOSITORY "git@github.com:Kitware/VTK.git" GIT_TAG ${tag})
+    set(location GIT_REPOSITORY "https://github.com/Kitware/VTK.git" GIT_TAG ${tag})
 endif()
 
 


### PR DESCRIPTION
This fixes the host key verification failure during the superbuild:

```
Cloning into 'VTK'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
-- Had to git clone more than once:
          3 times.
CMake Error at build/VTK/tmp/VTK-gitclone.cmake:56 (message):
  Failed to clone repository: 'git@github.com:Kitware/VTK.git'

```
Cloning VTK repository with HTTPS URL directly from github fixes the issue. 