### PR TITLE
[Jenkins] on windows need to remove ITK path length

### DIFF
--- a/cmake/externals/projects_modules/ITK.cmake
+++ b/cmake/externals/projects_modules/ITK.cmake
@@ -77,6 +77,7 @@ set(cmake_args
   -DBUILD_TESTING:BOOL=OFF
   -DModule_ITKIOPhilipsREC:BOOL=ON
   -DModule_ITKReview:BOOL=ON
+  -DITK_SKIP_PATH_LENGTH_CHECKS:BOOL=ON
   )
 
 ## #############################################################################
@@ -84,6 +85,7 @@ set(cmake_args
 ## #############################################################################
 
 ep_GeneratePatchCommand(ITK ITK_PATCH_COMMAND ITK_Mac_Rpath.patch)
+ep_GeneratePatchCommand(ITK ITK_PATCH_COMMAND ITK_Window_pathLength.patch)
 
 ## #############################################################################
 ## Add external-project

--- a/patches/ITK_Window_pathLength.patch
+++ b/patches/ITK_Window_pathLength.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e9f96bd..328402f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,7 @@ include(CMakeDependentOption)
+ # use ExternalProject
+ include(ExternalProject)
+ 
+-if( CMAKE_HOST_WIN32 )
++if( CMAKE_HOST_WIN32 AND NOT ITK_SKIP_PATH_LENGTH_CHECKS )
+ 
+   string( LENGTH "${CMAKE_CURRENT_SOURCE_DIR}" n )
+   if( n GREATER 50 )


### PR DESCRIPTION
In order to compile music on Jenkins through windows, this PR adds a small patch which is done on a later version of ITK (http://review.source.kitware.com/#/c/21462/1/CMakeLists.txt https://issues.itk.org/jira/browse/ITK-3462). When we'll update our ITK version used, we'll be able to remove the patch file.

The ITK size limit is not anymore needed on later versions of windows.

@fcollot can you look at this PR? i need it to continue on Jenkins

:m: