### PR TITLE
Ignore missing override warning

### DIFF
--- a/cmake/externals/projects_modules/medInria.cmake
+++ b/cmake/externals/projects_modules/medInria.cmake
@@ -70,7 +70,7 @@ set(git_tag master)
 ## #############################################################################
 
 # Set compilation flags
-set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -std=c++11") # Compile using c++11 standard
+set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -std=c++11 -Wno-inconsistent-missing-override") # Compile using c++11 standard
 set(${ep}_c_flags "${${ep}_c_flags} -Wall")
 
 set(cmake_args


### PR DESCRIPTION
Since passing to C++11, compiling MUSIC is very problematic on mac because clang is giving thousands of warnings about overriding methods not using the ```override``` keyword. The result is a huge list of warnings that hides the other warnings and makes it hard to find compilation issues.