### PR TITLE
[ConfigureSteps] Fix custom cmake patch command

### DIFF
--- a/cmake/externals/configuration_steps/EP_GeneratePatchCommand.cmake
+++ b/cmake/externals/configuration_steps/EP_GeneratePatchCommand.cmake
@@ -14,7 +14,7 @@ function(ep_GeneratePatchCommand ep OutVar)
         endif()
     endforeach()
 
-    set(PATCH_COMMAND)
+    set(PATCH_COMMAND "")
     if (NOT "${PATCHES_TO_APPLY}" STREQUAL "")
         set(PATCH_COMMAND git apply --ignore-whitespace ${PATCHES_TO_APPLY})
     endif()


### PR DESCRIPTION
- Fixes the dreaded "patch failed to apply" message

- Our external projects (music, medInria-private, music-private...) use a custom cmake function to handle patches during the configure step. This function first checks if the patch is applicable. The patch is applied if and only if the check passed.
There was a problem when the check did not pass, which, as expected, happens a lot.
It seems cmake is not fond of setting variables with no values as in:
`set(TOTO)`

This PR forces the value of PATCH_COMMAND to empty string when no patch needs to be applied.