### PR TITLE
[macOS] Fix VTK compilation bug on macOS

### DIFF
--- a/cmake/externals/projects_modules/VTK.cmake
+++ b/cmake/externals/projects_modules/VTK.cmake
@@ -85,6 +85,8 @@ set(cmake_args_generic
   -DBUILD_TESTING:BOOL=OFF 
   # OGV
   -DVTK_USE_OGGTHEORA_ENCODER:BOOL=ON
+  # To be removed when upgrading VTK version
+  -DVTK_REQUIRED_OBJCXX_FLAGS:STRING=""
   )
 
 if (WIN32)


### PR DESCRIPTION
- Force objective C flag to be empty. CMake currently does not support objective c flags .This problem has been fixed in recent versions of VTK.