### PR TITLE
Make package with virtualenv, afct/ventriclesegmentation learning modules & vtk 5

### DIFF
--- a/cmake/externals/projects_modules/VTK.cmake
+++ b/cmake/externals/projects_modules/VTK.cmake
@@ -109,6 +109,7 @@ set(cmake_args
   -DFFMPEG_swscale_LIBRARY:STRING=${CMAKE_CURRENT_SOURCE_DIR}/build/ffmpeg/build/lib/libswscale.${extention}
   -DVTK_WRAP_PYTHON:BOOL=ON
   -DVTK_USE_TK:BOOL=OFF
+  -DVTK_INSTALL_NO_PYTHON:BOOL=ON
   )
 endif()
   

--- a/cmake/externals/projects_modules/VTK.cmake
+++ b/cmake/externals/projects_modules/VTK.cmake
@@ -107,6 +107,8 @@ set(cmake_args
   -DFFMPEG_avformat_LIBRARY:STRING=${CMAKE_CURRENT_SOURCE_DIR}/build/ffmpeg/build/lib/libavformat.${extention}
   -DFFMPEG_avutil_LIBRARY:STRING=${CMAKE_CURRENT_SOURCE_DIR}/build/ffmpeg/build/lib/libavutil.${extention}
   -DFFMPEG_swscale_LIBRARY:STRING=${CMAKE_CURRENT_SOURCE_DIR}/build/ffmpeg/build/lib/libswscale.${extention}
+  -DVTK_WRAP_PYTHON:BOOL=ON
+  -DVTK_USE_TK:BOOL=OFF
   )
 endif()
   

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash -xe
 
 # Usage: 
 # - mac_packager.sh plugin1 plugin2 ... pluginN
@@ -42,29 +42,7 @@ done
 cd MUSIC.app/Contents
 
 mkdir -p python_interpreter
-cp -p @PROJECT_BINARY_DIR@/python_interpreter/music-py27.tar.gz python_interpreter/.
-
-
-mkdir -p PlugIns/sqldrivers PlugIns/imageformats
-
-cp -p @QT_PLUGINS_DIR@/sqldrivers/libqsqlite.dylib PlugIns/sqldrivers/libqsqlite.dylib
-cp -p @QT_PLUGINS_DIR@/imageformats/libqsvg.dylib PlugIns/imageformats/libqsvg.dylib
-
-for f in PlugIns/{sqldrivers/libqsqlite,imageformats/libqsvg}.dylib
-do
-	#Qt stuff (should hopefully be there already)
-	for j in $( otool -L $f | sed "1d" | grep -E .framework | grep -i -E 'Qt|phonon' | cut -d " " -f 1 ); do
-		#Depending on Qt SDK, paths may be relative or not
-		#tmpVal=`echo $j | rev | cut -d "/" -f 1-4 | rev`
-		if [ "`echo $j | grep executable_path`" == "" ]; then
-			install_name_tool -change $j @executable_path/../Frameworks/$j $f
-		fi
-    done
-done
-
-# change library paths for qsqlite
-install_name_tool -change @executable_path/../Frameworks//usr/local/Cellar/qt/4.8.7_3/lib/QtSql.framework/Versions/4/QtSql @executable_path/../Frameworks/QtSql.framework/Versions/4/QtSql PlugIns/sqldrivers/libqsqlite.dylib
-install_name_tool -change @executable_path/../Frameworks//usr/local/Cellar/qt/4.8.7_3/lib/QtCore.framework/Versions/4/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/4/QtCore PlugIns/sqldrivers/libqsqlite.dylib
+cp -rf @PROJECT_BINARY_DIR@/python_interpreter .
 
 # change library paths for plugins
 for f in PlugIns/*.dylib

--- a/packaging/python/python_packager.sh.in
+++ b/packaging/python/python_packager.sh.in
@@ -24,13 +24,14 @@ else
 	echo "music-learning directory does not exists."
 fi
 
-# Get vtk-5.10.1 python module from music-utilities repository
-# And add it in MUSIC binary
-# Change dynamic shared library install names for embedded *.so in modules
+# 1) Change dynamic shared library install names for embedded *.so in modules
 # Only useful for macosx
+# 2) Generate vtk-5.10.1 python module from VTK Wrapping build directory (wheel)
+# 3) And add it in MUSIC binary
 cd @PROJECT_BINARY_DIR@
-VTK_DIR=@PROJECT_BINARY_DIR@/../../python-packages/vtk-5.10.1/
-VTK_BIN_DIR=$VTK_DIR/bin
+VTK_BUILD_DIR=@PROJECT_BINARY_DIR@/VTK/build
+VTK_WRAP_DIR=$VTK_BUILD_DIR/Wrapping/Python
+VTK_BIN_DIR=$VTK_BUILD_DIR/bin
 OSTYPE="`uname`"
 if [ ! -z "$VTK_DIR" ]; then
 	if [ "$OSTYPE" = "Darwin" ]; then
@@ -53,12 +54,13 @@ if [ ! -z "$VTK_DIR" ]; then
 		
 		done
 	fi
-	cd "$VTK_DIR"
-	zip -r vtk-5.10.1.zip .
+	cd "$VTK_WRAP_DIR"
+	python setup.py bdist_wheel
 	if [ "$?" != "0" ]; then
-		printf "[Warning] unable to compress vtk python wrapping directory. It will be not available in package" 
+		printf "[Warning] unable to generate vtk python package (wheel). It will be not available in package" 
 	else
-		mv vtk-5.10.1.zip @PROJECT_BINARY_DIR@/python_interpreter/.
+		cd dist
+		mv VTK-5.10.1-*.whl @PROJECT_BINARY_DIR@/python_interpreter/vtk-5.10.1.whl
 	fi
 else
 	echo "you must build vtk with python wrapping enabled."

--- a/packaging/python/python_packager.sh.in
+++ b/packaging/python/python_packager.sh.in
@@ -1,24 +1,70 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
-for i in $*; do
-	# Set some plugin dirs
-	if [[ $i = *"musicPlugins"* ]]; then
-		musicPythonInterpreterDir="$i/medPipeline/python/interpreter"
-	fi
-done
-
-# copy python interpreter (the compressed one) 
-if [ ! -f $musicPythonInterpreterDir/music-py27.tar.gz ]; then
-
-	virtualenv --version
-	cd $musicPythonInterpreterDir
-	virtualenv -p /usr/bin/python2.7 music-py27
-	source music-py27/bin/activate
-	pip install -r requirements.txt
-	deactivate
-	tar -zcvf music-py27.tar.gz music-py27 
-fi
+pwd
 
 cd @PROJECT_BINARY_DIR@
 mkdir -p python_interpreter
-cp -p $musicPythonInterpreterDir/music-py27.tar.gz python_interpreter/.
+
+MUSIC_LEARNING_DIR=@PROJECT_BINARY_DIR@/../../music-learning
+
+if [ ! -z "$MUSIC_LEARNING_DIR" ]; then
+	cd $MUSIC_LEARNING_DIR
+	zip -r ventriclesegmentation.zip ventriclesegmentation
+	if [ "$?" != "0" ]; then
+		printf "[Warning] unable to compress ventriclesegmentation repository. It will be not available in package" 
+	else
+		mv ventriclesegmentation.zip @PROJECT_BINARY_DIR@/python_interpreter/.
+	fi
+	zip -r afct.zip afct
+	if [ "$?" != "0" ]; then
+		printf "[Warning] unable to compress afct repository. It will be not available in package" 
+	else
+		mv afct.zip @PROJECT_BINARY_DIR@/python_interpreter/.
+	fi
+else
+	echo "music-learning directory does not exists."
+fi
+
+cd @PROJECT_BINARY_DIR@
+
+VTK_DIR=@PROJECT_BINARY_DIR@/../../python-packages/vtk-5.10.1/
+VTK_BIN_DIR=$VTK_DIR/bin
+OSTYPE="`uname`"
+
+if [ ! -z "$VTK_DIR" ]; then
+	if [ "$OSTYPE" = "Darwin" ]; then
+		cd $VTK_BIN_DIR
+		for f in *.so
+		do
+			for j in $( otool -L $f  | sed "1d" | grep -E .dylib | grep -i -E 'vtk' | cut -d " " -f 1 ); do
+				tmpVal=`echo $j | rev | cut -d "/" -f 1 | rev`
+				if [ "`echo $j | grep executable_path`" == "" ]; then
+					install_name_tool -change $j @executable_path/../Frameworks/$tmpVal $f
+				fi
+		    done	
+			for j in $( otool -L $f | sed "1d" | grep -E .framework | grep -i -E 'Qt|phonon' | cut -d " " -f 1 ); do
+				k=$(echo $(sed 's/\(\.framework\).*/\1/' <<<$j) | rev | cut -d/ -f1 | rev)
+				l=$(awk -F'\\.framework' '{print $2}' <<< $j)
+				if [ "`echo $j | grep executable_path`" == "" ]; then
+					install_name_tool -change $j @executable_path/../Frameworks/$k$l $f
+				fi
+			done
+		
+		done
+	fi
+	cd "$VTK_DIR"
+	zip -r vtk-5.10.1.zip .
+	if [ "$?" != "0" ]; then
+		printf "[Warning] unable to compress vtk python wrapping directory. It will be not available in package" 
+	else
+		mv vtk-5.10.1.zip @PROJECT_BINARY_DIR@/python_interpreter/.
+	fi
+else
+	echo "you must build vtk with python wrapping enabled."
+fi
+
+cd @PROJECT_BINARY_DIR@
+cd python_interpreter
+curl --location --output virtualenv-16.4.3.tar.gz https://github.com/pypa/virtualenv/tarball/16.4.3
+
+cd @PROJECT_BINARY_DIR@

--- a/packaging/python/python_packager.sh.in
+++ b/packaging/python/python_packager.sh.in
@@ -33,7 +33,7 @@ VTK_BUILD_DIR=@PROJECT_BINARY_DIR@/VTK/build
 VTK_WRAP_DIR=$VTK_BUILD_DIR/Wrapping/Python
 VTK_BIN_DIR=$VTK_BUILD_DIR/bin
 OSTYPE="`uname`"
-if [ ! -z "$VTK_DIR" ]; then
+if [ ! -z "$VTK_WRAP_DIR" ]; then
 	if [ "$OSTYPE" = "Darwin" ]; then
 		cd $VTK_BIN_DIR
 		for f in *.so
@@ -60,7 +60,7 @@ if [ ! -z "$VTK_DIR" ]; then
 		printf "[Warning] unable to generate vtk python package (wheel). It will be not available in package" 
 	else
 		cd dist
-		mv VTK-5.10.1-*.whl @PROJECT_BINARY_DIR@/python_interpreter/vtk-5.10.1.whl
+		mv VTK-5.10.1-py2-none-any.whl @PROJECT_BINARY_DIR@/python_interpreter/.
 	fi
 else
 	echo "you must build vtk with python wrapping enabled."

--- a/packaging/python/python_packager.sh.in
+++ b/packaging/python/python_packager.sh.in
@@ -1,12 +1,11 @@
 #!/bin/bash -e
 
-pwd
-
 cd @PROJECT_BINARY_DIR@
 mkdir -p python_interpreter
 
+# Get afct & ventriclesegmentation python modules from music-learning gitlab repo
+# And add them in MUSIC binary
 MUSIC_LEARNING_DIR=@PROJECT_BINARY_DIR@/../../music-learning
-
 if [ ! -z "$MUSIC_LEARNING_DIR" ]; then
 	cd $MUSIC_LEARNING_DIR
 	zip -r ventriclesegmentation.zip ventriclesegmentation
@@ -25,12 +24,14 @@ else
 	echo "music-learning directory does not exists."
 fi
 
+# Get vtk-5.10.1 python module from music-utilities repository
+# And add it in MUSIC binary
+# Change dynamic shared library install names for embedded *.so in modules
+# Only useful for macosx
 cd @PROJECT_BINARY_DIR@
-
 VTK_DIR=@PROJECT_BINARY_DIR@/../../python-packages/vtk-5.10.1/
 VTK_BIN_DIR=$VTK_DIR/bin
 OSTYPE="`uname`"
-
 if [ ! -z "$VTK_DIR" ]; then
 	if [ "$OSTYPE" = "Darwin" ]; then
 		cd $VTK_BIN_DIR


### PR DESCRIPTION
This PR is linked with PR [#690](https://github.com/Inria-Asclepios/music/pull/690).

The aim is to build a package according to the tree below.

**Mac OS Package Tree :** 
```
MUSIC.app
└── Contents
    ├── Frameworks
    ├── Info.plist
    ├── MacOS
    ├── PlugIns
    ├── Resources
    └── python_interpreter
               └── afct.zip
               ├── ventriclesegmentation.zip
               ├── virtualenv-16.4.3.tar.gz
               └── vtk-5.10.1.zip
```
**Linux Package Tree:**
```
MUSIC-2.4.0/
├── bin
├── lib
├── plugins
└── python_interpreter
               └── afct.zip
               ├── ventriclesegmentation.zip
               ├── virtualenv-16.4.3.tar.gz
               └── vtk-5.10.1.zip
```
1. VTK is build with python wrapping enabled
2. The python packager shell script is copying the required modules (format zip)  in the package tree.