### PR TITLE
[DCMTK] Fix DICOM import failure

### DIFF
--- a/cmake/externals/projects_modules/DCMTK.cmake
+++ b/cmake/externals/projects_modules/DCMTK.cmake
@@ -75,7 +75,7 @@ set(cmake_args
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  
-  -DCMAKE_INSTALL_PREFIX:PATH=<BINARY_DIR>
+  -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
   -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${ep}}
   -DDCMTK_WITH_DOXYGEN:BOOL=OFF
   -DDCMTK_WITH_ZLIB:BOOL=OFF    
@@ -101,7 +101,6 @@ ExternalProject_Add(${ep}
   UPDATE_COMMAND ""
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS ${cmake_args}
-  INSTALL_COMMAND ""
   )
 
 
@@ -109,8 +108,8 @@ ExternalProject_Add(${ep}
 ## Set variable to provide infos about the project
 ## #############################################################################
 
-ExternalProject_Get_Property(${ep} binary_dir)
-set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
+ExternalProject_Get_Property(${ep} install_dir)
+set(${ep}_DIR ${install_dir} PARENT_SCOPE)
 
 
 ## #############################################################################

--- a/cmake/externals/projects_modules/DCMTK.cmake
+++ b/cmake/externals/projects_modules/DCMTK.cmake
@@ -75,7 +75,7 @@ set(cmake_args
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  
-  -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  -DCMAKE_INSTALL_PREFIX:PATH=<BINARY_DIR>
   -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${ep}}
   -DDCMTK_WITH_DOXYGEN:BOOL=OFF
   -DDCMTK_WITH_ZLIB:BOOL=OFF    
@@ -86,6 +86,9 @@ set(cmake_args
   -DDCMTK_WITH_ICONV:BOOL=OFF    
   -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS:BOOL=OFF
   -DDCMTK_ENABLE_CXX11:BOOL=ON
+  -DDCMTK_ENABLE_BUILTIN_DICTIONARY:BOOL=ON
+  -DDCMTK_ENABLE_PRIVATE_TAGS:BOOL=ON
+  -DDCMTK_FORCE_FPIC_ON_UNIX:BOOL=ON
   )
 
 ## #############################################################################
@@ -98,6 +101,7 @@ ExternalProject_Add(${ep}
   UPDATE_COMMAND ""
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS ${cmake_args}
+  INSTALL_COMMAND ""
   )
 
 
@@ -105,8 +109,8 @@ ExternalProject_Add(${ep}
 ## Set variable to provide infos about the project
 ## #############################################################################
 
-ExternalProject_Get_Property(${ep} install_dir)
-set(${ep}_DIR ${install_dir} PARENT_SCOPE)
+ExternalProject_Get_Property(${ep} binary_dir)
+set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
 
 
 ## #############################################################################

--- a/packaging/unix/MUSIC.sh.in
+++ b/packaging/unix/MUSIC.sh.in
@@ -31,7 +31,7 @@ MEDINRIA_BIN="@MEDINRIA_BIN@"
 #   Set the plugins and library paths.
 
 export MEDINRIA_PLUGIN_PATH="@MEDINRIA_PLUGINS_DIRS@"
-export LD_LIBRARY_PATH=${MEDINRIA_DIR}/lib:${MEDINRIA_DIR}/DCMTK/install/lib:${MEDINRIA_DIR}/lib/vtk-5.10:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${MEDINRIA_DIR}/lib:${MEDINRIA_DIR}/lib/vtk-5.10:$LD_LIBRARY_PATH
 
 #   Call medInria
 


### PR DESCRIPTION
- Dicom dictionary now set to be builtin the libs
- Remove DCMTK lib path from LD_LIBRARY_PATH in Music launcher script.